### PR TITLE
Added no-param-reassign rule

### DIFF
--- a/configurations/es6-node.js
+++ b/configurations/es6-node.js
@@ -24,6 +24,8 @@ module.exports = {
     // suggest using Reflect methods where applicable
     "prefer-reflect": 0,
     // require that all functions are run in strict mode
-    strict: [2, "global"]
+    strict: [2, "global"],
+    // warn on function param reassignment or mutation
+    "no-param-reassign": 1
   }
 };


### PR DESCRIPTION
This rule config warns on function param reassignment or mutation (since both of these things are odd side effects which can cause  errors that are hard to track down). Here's [more info on this eslint rule](http://eslint.org/docs/rules/no-param-reassign).